### PR TITLE
feat: Pathogens II

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,13 @@
 
     <script src="scripts/entities/status_effects/base_status_effect.js"></script>
     <script src="scripts/entities/status_effects/interfered_effect.js"></script>
+    <script src="scripts/entities/status_effects/inoculated_effect.js"></script>
     <script src="scripts/entities/adaptation.js"></script>
     <script src="scripts/entities/damage_number.js"></script>
     <script src="scripts/entities/pop_effect.js"></script>
     <script src="scripts/entities/wave_effect.js"></script>
     <script src="scripts/entities/explosion_effect.js"></script>
+    <script src="scripts/entities/lightning_effect.js"></script>
     <script src="scripts/entities/projectile.js"></script>
     <script src="scripts/entities/phenotype_projectile.js"></script>
     <script src="scripts/entities/phenotype.js"></script>
@@ -136,6 +138,7 @@
     <script src="scripts/entities/enemies/basic_enemy.js"></script>
     <script src="scripts/entities/enemies/microbe.js"></script>
     <script src="scripts/entities/enemies/mycetoma.js"></script>
+    <script src="scripts/entities/enemies/rickettsia.js"></script>
 
     <script src="scripts/entities/phenotypes/perforin_pulse.js"></script>
 

--- a/scripts/config/adaptation_configs.js
+++ b/scripts/config/adaptation_configs.js
@@ -153,9 +153,9 @@ const ADAPTATION_CONFIGS = {
         },
         get descriptions() {
             return {
-                0: `Increase status effect durations by ${Math.round((this.effects[0].status_effect_duration_multiplier - 1) * 100)}%.`,
-                1: `Increase status effect durations by ${Math.round((this.effects[1].status_effect_duration_multiplier - 1) * 100)}%.`,
-                2: `Increase status effect durations by ${Math.round((this.effects[2].status_effect_duration_multiplier - 1) * 100)}%.`
+                0: `Increase Immune Cell-applied status effect durations by ${Math.round((this.effects[0].status_effect_duration_multiplier - 1) * 100)}%.`,
+                1: `Increase Immune Cell-applied status effect durations by ${Math.round((this.effects[1].status_effect_duration_multiplier - 1) * 100)}%.`,
+                2: `Increase Immune Cell-applied status effect durations by ${Math.round((this.effects[2].status_effect_duration_multiplier - 1) * 100)}%.`
             };
         }
     },

--- a/scripts/config/pathogen_configs.js
+++ b/scripts/config/pathogen_configs.js
@@ -10,15 +10,31 @@ const PATHOGEN_CONFIGS = {
         color: '#556B2F',
         stroke_color: '#000000',
         stroke_width: 2
+    },
+    RICKETTSIA: {
+        min_hp: 40,
+        max_hp: 40,
+        min_speed: 0.5,
+        max_speed: 0.5,
+        min_size_mod: 1.0,
+        max_size_mod: 1.0,
+        base_radius: 20,
+        color: '#FFA500',
+        stroke_color: '#000000',
+        stroke_width: 2,
+        action_interval_ms: 2000,
+        inoculation_range: 200
     }
 };
 
 const PATHOGEN_TYPES = {
-    MYCETOMA: 'MYCETOMA'
+    MYCETOMA: 'MYCETOMA',
+    RICKETTSIA: 'RICKETTSIA'
 };
 
 const PATHOGEN_POOL = [
-    PATHOGEN_TYPES.MYCETOMA
+    PATHOGEN_TYPES.MYCETOMA,
+    PATHOGEN_TYPES.RICKETTSIA
 ];
 
 window.PATHOGEN_CONFIGS = PATHOGEN_CONFIGS;

--- a/scripts/entities/enemies/base_enemy.js
+++ b/scripts/entities/enemies/base_enemy.js
@@ -143,6 +143,10 @@ class BaseEnemy {
     }
 
     is_immune_to_status_effect(effect) {
+        if (!effect) {
+            return false;
+        }
+
         if (!this.has_inoculated_status()) {
             return false;
         }

--- a/scripts/entities/enemies/base_enemy.js
+++ b/scripts/entities/enemies/base_enemy.js
@@ -11,10 +11,14 @@ class BaseEnemy {
         this.displayed_hp = this.hp;
         this.base_speed = this.generate_speed_from_size();
         this.current_speed = this.base_speed;
-        this.radius = this.generate_radius_from_size();
+        this.base_radius = this.generate_radius_from_size();
+        this.radius = this.base_radius;
         this.color = this.generate_color();
         this.pulsate_effect = new PulsateEffect();
         this.status_effects = [];
+        this.inoculated_size_multiplier = 1.0;
+        this.inoculated_speed_multiplier = 1.0;
+        this.immunity_feedback_timer = 0;
     }
 
     generate_size_modifier() {
@@ -99,10 +103,17 @@ class BaseEnemy {
         });
         
         this.calculate_current_speed();
+        this.update_immunity_feedback_timer();
+    }
+
+    update_immunity_feedback_timer() {
+        if (this.immunity_feedback_timer > 0) {
+            this.immunity_feedback_timer--;
+        }
     }
 
     calculate_current_speed() {
-        this.current_speed = this.base_speed;
+        this.current_speed = this.base_speed * this.inoculated_speed_multiplier;
         
         this.status_effects.forEach(effect => {
             if (effect.get_type() === 'INTERFERED') {
@@ -112,6 +123,11 @@ class BaseEnemy {
     }
 
     add_status_effect(effect) {
+        if (this.is_immune_to_status_effect(effect)) {
+            this.trigger_immunity_feedback();
+            return false;
+        }
+
         const existing_effect_index = this.status_effects.findIndex(
             existing => existing.get_type() === effect.get_type()
         );
@@ -123,10 +139,44 @@ class BaseEnemy {
         
         this.status_effects.push(effect);
         effect.apply_effect(this);
+        return true;
+    }
+
+    is_immune_to_status_effect(effect) {
+        if (!this.has_inoculated_status()) {
+            return false;
+        }
+
+        return effect.is_from_immune_cell();
+    }
+
+    has_inoculated_status() {
+        return this.has_status_effect('INOCULATED');
+    }
+
+    trigger_immunity_feedback() {
+        this.immunity_feedback_timer = 60;
+        
+        if (window.game_state && window.game_state.effects) {
+            const immunity_text = new ImmunityFeedbackText(this.x, this.y);
+            window.game_state.effects.push(immunity_text);
+        }
     }
 
     has_status_effect(effect_type) {
         return this.status_effects.some(effect => effect.get_type() === effect_type);
+    }
+
+    apply_inoculated_bonuses(size_multiplier, speed_multiplier) {
+        this.inoculated_size_multiplier = size_multiplier;
+        this.inoculated_speed_multiplier = speed_multiplier;
+        this.radius = this.base_radius * this.inoculated_size_multiplier;
+    }
+
+    remove_inoculated_bonuses() {
+        this.inoculated_size_multiplier = 1.0;
+        this.inoculated_speed_multiplier = 1.0;
+        this.radius = this.base_radius;
     }
 
     draw_hp_gauge(ctx) {
@@ -206,4 +256,46 @@ class BaseEnemy {
     }
 }
 
+class ImmunityFeedbackText {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.text = 'IMMUNE';
+        this.life = 60;
+        this.max_life = 60;
+        this.opacity = 1.0;
+        this.float_speed = 1.0;
+        this.color = '#FFD700';
+    }
+
+    update() {
+        this.y -= this.float_speed;
+        this.life--;
+        this.opacity = this.life / this.max_life;
+    }
+
+    draw(ctx) {
+        if (this.life <= 0) {
+            return;
+        }
+
+        ctx.save();
+        ctx.globalAlpha = this.opacity;
+        ctx.fillStyle = this.color;
+        ctx.strokeStyle = '#000000';
+        ctx.lineWidth = 2;
+        ctx.font = 'bold 14px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.strokeText(this.text, this.x, this.y);
+        ctx.fillText(this.text, this.x, this.y);
+        ctx.restore();
+    }
+
+    is_alive() {
+        return this.life > 0;
+    }
+}
+
 window.BaseEnemy = BaseEnemy;
+window.ImmunityFeedbackText = ImmunityFeedbackText;

--- a/scripts/entities/enemies/rickettsia.js
+++ b/scripts/entities/enemies/rickettsia.js
@@ -1,0 +1,139 @@
+class Rickettsia extends BaseEnemy {
+    constructor(x, y) {
+        super(x, y, PATHOGEN_CONFIGS.RICKETTSIA, ENEMY_CATEGORIES.PATHOGEN, PATHOGEN_TYPES.RICKETTSIA);
+        this.last_action_time = 0;
+        this.action_interval_ms = this.config.action_interval_ms;
+        this.inoculation_range = this.config.inoculation_range;
+    }
+
+    update(target, timestamp) {
+        this.update_status_effects(timestamp);
+        this.move_toward_target(target);
+        this.attempt_inoculation_action(timestamp);
+    }
+
+    attempt_inoculation_action(timestamp) {
+        if (!this.last_action_time) {
+            this.last_action_time = this.get_current_adjusted_time(timestamp);
+            return;
+        }
+
+        const adjusted_elapsed = this.get_adjusted_elapsed_time_since_last_action(timestamp);
+        
+        if (adjusted_elapsed >= this.action_interval_ms) {
+            this.perform_inoculation_action();
+            this.last_action_time = this.get_current_adjusted_time(timestamp);
+        }
+    }
+
+    get_current_adjusted_time(timestamp) {
+        if (window.game_state && window.game_state.get_adjusted_elapsed_time) {
+            return window.game_state.get_adjusted_elapsed_time(0);
+        }
+        return timestamp;
+    }
+
+    get_adjusted_elapsed_time_since_last_action(timestamp) {
+        const current_adjusted_time = this.get_current_adjusted_time(timestamp);
+        return current_adjusted_time - this.last_action_time;
+    }
+
+    perform_inoculation_action() {
+        const eligible_microbe = this.find_eligible_microbe();
+        
+        if (!eligible_microbe) {
+            return;
+        }
+
+        this.apply_inoculation_to_microbe(eligible_microbe);
+        this.create_lightning_effect_to_target(eligible_microbe);
+        this.play_lightning_sound();
+    }
+
+    find_eligible_microbe() {
+        if (!window.game_state || !window.game_state.enemies) {
+            return null;
+        }
+
+        const eligible_microbes = window.game_state.enemies.filter(enemy => 
+            this.is_eligible_microbe(enemy)
+        );
+
+        if (eligible_microbes.length === 0) {
+            return null;
+        }
+
+        const random_index = Math.floor(Math.random() * eligible_microbes.length);
+        return eligible_microbes[random_index];
+    }
+
+    is_eligible_microbe(enemy) {
+        if (!enemy.is_microbe()) {
+            return false;
+        }
+
+        if (!this.is_in_inoculation_range(enemy)) {
+            return false;
+        }
+
+        if (this.has_inoculated_status(enemy)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    is_in_inoculation_range(target) {
+        const distance = MathUtils.get_distance(this.x, this.y, target.x, target.y);
+        return distance <= this.inoculation_range;
+    }
+
+    has_inoculated_status(enemy) {
+        return enemy.has_status_effect('INOCULATED');
+    }
+
+    apply_inoculation_to_microbe(microbe) {
+        this.clear_immune_cell_status_effects(microbe);
+        this.apply_inoculated_status_effect(microbe);
+    }
+
+    clear_immune_cell_status_effects(microbe) {
+        if (!microbe.status_effects) {
+            return;
+        }
+
+        const effects_to_remove = microbe.status_effects.filter(effect => 
+            effect.is_from_immune_cell()
+        );
+
+        effects_to_remove.forEach(effect => {
+            effect.remove_effect(microbe);
+            const effect_index = microbe.status_effects.indexOf(effect);
+            if (effect_index !== -1) {
+                microbe.status_effects.splice(effect_index, 1);
+            }
+        });
+    }
+
+    apply_inoculated_status_effect(microbe) {
+        const inoculated_effect = new InoculatedEffect();
+        microbe.add_status_effect(inoculated_effect);
+    }
+
+    create_lightning_effect_to_target(target) {
+        if (!window.game_state || !window.game_state.effects) {
+            return;
+        }
+
+        const lightning = new LightningEffect(this.x, this.y, target.x, target.y);
+        window.game_state.effects.push(lightning);
+    }
+
+    play_lightning_sound() {
+        if (window.game_state && window.game_state.audio_system) {
+            window.game_state.audio_system.play_sound('APPLY_LIGHTNING');
+        }
+    }
+}
+
+window.Rickettsia = Rickettsia;

--- a/scripts/entities/enemies/rickettsia.js
+++ b/scripts/entities/enemies/rickettsia.js
@@ -56,7 +56,7 @@ class Rickettsia extends BaseEnemy {
         }
 
         const eligible_microbes = window.game_state.enemies.filter(enemy => 
-            this.is_eligible_microbe(enemy)
+            enemy && this.is_eligible_microbe(enemy)
         );
 
         if (eligible_microbes.length === 0) {
@@ -68,6 +68,10 @@ class Rickettsia extends BaseEnemy {
     }
 
     is_eligible_microbe(enemy) {
+        if (!enemy) {
+            return false;
+        }
+
         if (!enemy.is_microbe()) {
             return false;
         }
@@ -84,26 +88,35 @@ class Rickettsia extends BaseEnemy {
     }
 
     is_in_inoculation_range(target) {
+        if (!target) {
+            return false;
+        }
         const distance = MathUtils.get_distance(this.x, this.y, target.x, target.y);
         return distance <= this.inoculation_range;
     }
 
     has_inoculated_status(enemy) {
+        if (!enemy || !enemy.has_status_effect) {
+            return false;
+        }
         return enemy.has_status_effect('INOCULATED');
     }
 
     apply_inoculation_to_microbe(microbe) {
+        if (!microbe) {
+            return;
+        }
         this.clear_immune_cell_status_effects(microbe);
         this.apply_inoculated_status_effect(microbe);
     }
 
     clear_immune_cell_status_effects(microbe) {
-        if (!microbe.status_effects) {
+        if (!microbe || !microbe.status_effects) {
             return;
         }
 
         const effects_to_remove = microbe.status_effects.filter(effect => 
-            effect.is_from_immune_cell()
+            effect && typeof effect.is_from_immune_cell === 'function' && effect.is_from_immune_cell()
         );
 
         effects_to_remove.forEach(effect => {
@@ -116,12 +129,15 @@ class Rickettsia extends BaseEnemy {
     }
 
     apply_inoculated_status_effect(microbe) {
+        if (!microbe || !microbe.add_status_effect) {
+            return;
+        }
         const inoculated_effect = new InoculatedEffect();
         microbe.add_status_effect(inoculated_effect);
     }
 
     create_lightning_effect_to_target(target) {
-        if (!window.game_state || !window.game_state.effects) {
+        if (!target || !window.game_state || !window.game_state.effects) {
             return;
         }
 

--- a/scripts/entities/lightning_effect.js
+++ b/scripts/entities/lightning_effect.js
@@ -1,0 +1,96 @@
+class LightningEffect {
+    constructor(start_x, start_y, end_x, end_y) {
+        this.start_x = start_x;
+        this.start_y = start_y;
+        this.end_x = end_x;
+        this.end_y = end_y;
+        this.life = 30;
+        this.max_life = 30;
+        this.opacity = 1.0;
+        this.segments = [];
+        this.generate_zigzag_pattern();
+    }
+
+    generate_zigzag_pattern() {
+        const distance = MathUtils.get_distance(this.start_x, this.start_y, this.end_x, this.end_y);
+        const segment_count = Math.max(3, Math.floor(distance / 30));
+        const base_angle = MathUtils.get_angle_between(this.start_x, this.start_y, this.end_x, this.end_y);
+        
+        this.segments = [];
+        
+        for (let i = 0; i <= segment_count; i++) {
+            const progress = i / segment_count;
+            const base_x = this.start_x + (this.end_x - this.start_x) * progress;
+            const base_y = this.start_y + (this.end_y - this.start_y) * progress;
+            
+            let offset_x = 0;
+            let offset_y = 0;
+            
+            if (i > 0 && i < segment_count) {
+                const zigzag_amplitude = 15;
+                const perpendicular_angle = base_angle + Math.PI / 2;
+                const offset_amount = (Math.random() - 0.5) * zigzag_amplitude;
+                offset_x = Math.cos(perpendicular_angle) * offset_amount;
+                offset_y = Math.sin(perpendicular_angle) * offset_amount;
+            }
+            
+            this.segments.push({
+                x: base_x + offset_x,
+                y: base_y + offset_y
+            });
+        }
+    }
+
+    update() {
+        this.life--;
+        this.opacity = Math.max(0, this.life / this.max_life);
+        
+        if (this.life <= 0) {
+            this.opacity = 0;
+        }
+    }
+
+    draw(ctx) {
+        if (this.life <= 0 || this.segments.length < 2) {
+            return;
+        }
+
+        ctx.save();
+        ctx.globalAlpha = this.opacity;
+        ctx.strokeStyle = '#00FFFF';
+        ctx.lineWidth = 3;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        
+        ctx.shadowColor = '#00FFFF';
+        ctx.shadowBlur = 8;
+
+        ctx.beginPath();
+        ctx.moveTo(this.segments[0].x, this.segments[0].y);
+        
+        for (let i = 1; i < this.segments.length; i++) {
+            ctx.lineTo(this.segments[i].x, this.segments[i].y);
+        }
+        
+        ctx.stroke();
+
+        ctx.lineWidth = 1;
+        ctx.shadowBlur = 0;
+        ctx.strokeStyle = '#FFFFFF';
+        ctx.beginPath();
+        ctx.moveTo(this.segments[0].x, this.segments[0].y);
+        
+        for (let i = 1; i < this.segments.length; i++) {
+            ctx.lineTo(this.segments[i].x, this.segments[i].y);
+        }
+        
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    is_alive() {
+        return this.life > 0;
+    }
+}
+
+window.LightningEffect = LightningEffect;

--- a/scripts/entities/status_effects/base_status_effect.js
+++ b/scripts/entities/status_effects/base_status_effect.js
@@ -1,6 +1,13 @@
+const STATUS_EFFECT_SOURCES = {
+    IMMUNE_CELL: 'IMMUNE_CELL',
+    PATHOGEN: 'PATHOGEN',
+    OTHER: 'OTHER'
+};
+
 class BaseStatusEffect {
-    constructor(duration_ms) {
+    constructor(duration_ms, source_category = STATUS_EFFECT_SOURCES.OTHER) {
         this.base_duration_ms = duration_ms;
+        this.source_category = source_category;
         this.duration_ms = this.apply_duration_modifier(duration_ms);
         this.remaining_time_ms = this.duration_ms;
         this.start_time = performance.now();
@@ -8,7 +15,7 @@ class BaseStatusEffect {
 
     apply_duration_modifier(base_duration) {
         if (window.game_state && window.game_state.adaptation_system) {
-            const multiplier = window.game_state.adaptation_system.get_status_effect_duration_multiplier();
+            const multiplier = window.game_state.adaptation_system.get_status_effect_duration_multiplier(this.source_category);
             return Math.ceil(base_duration * multiplier);
         }
         return base_duration;
@@ -31,6 +38,18 @@ class BaseStatusEffect {
         return 'BASE';
     }
 
+    get_source_category() {
+        return this.source_category;
+    }
+
+    is_from_immune_cell() {
+        return this.source_category === STATUS_EFFECT_SOURCES.IMMUNE_CELL;
+    }
+
+    is_from_pathogen() {
+        return this.source_category === STATUS_EFFECT_SOURCES.PATHOGEN;
+    }
+
     apply_effect(target) {
         
     }
@@ -41,3 +60,4 @@ class BaseStatusEffect {
 }
 
 window.BaseStatusEffect = BaseStatusEffect;
+window.STATUS_EFFECT_SOURCES = STATUS_EFFECT_SOURCES;

--- a/scripts/entities/status_effects/inoculated_effect.js
+++ b/scripts/entities/status_effects/inoculated_effect.js
@@ -12,15 +12,17 @@ class InoculatedEffect extends BaseStatusEffect {
     }
 
     apply_effect(target) {
-        if (target.apply_inoculated_bonuses) {
-            target.apply_inoculated_bonuses(this.size_multiplier, this.speed_multiplier);
+        if (!target || !target.apply_inoculated_bonuses) {
+            return;
         }
+        target.apply_inoculated_bonuses(this.size_multiplier, this.speed_multiplier);
     }
 
     remove_effect(target) {
-        if (target.remove_inoculated_bonuses) {
-            target.remove_inoculated_bonuses();
+        if (!target || !target.remove_inoculated_bonuses) {
+            return;
         }
+        target.remove_inoculated_bonuses();
     }
 
     update(timestamp) {
@@ -59,12 +61,17 @@ class InoculatedEffect extends BaseStatusEffect {
         }
 
         return window.game_state.enemies.find(enemy => 
+            enemy && 
             enemy.status_effects && 
             enemy.status_effects.includes(this)
         );
     }
 
     create_inoculated_particle(target) {
+        if (!target) {
+            return null;
+        }
+
         const angle = Math.random() * Math.PI * 2;
         const distance = Math.random() * target.radius * 0.8;
         const particle_x = target.x + Math.cos(angle) * distance;

--- a/scripts/entities/status_effects/inoculated_effect.js
+++ b/scripts/entities/status_effects/inoculated_effect.js
@@ -1,0 +1,125 @@
+class InoculatedEffect extends BaseStatusEffect {
+    constructor() {
+        super(Number.MAX_SAFE_INTEGER, STATUS_EFFECT_SOURCES.PATHOGEN);
+        this.size_multiplier = 1.5;
+        this.speed_multiplier = 1.5;
+        this.particle_spawn_timer = 0;
+        this.particle_spawn_interval = 200;
+    }
+
+    get_type() {
+        return 'INOCULATED';
+    }
+
+    apply_effect(target) {
+        if (target.apply_inoculated_bonuses) {
+            target.apply_inoculated_bonuses(this.size_multiplier, this.speed_multiplier);
+        }
+    }
+
+    remove_effect(target) {
+        if (target.remove_inoculated_bonuses) {
+            target.remove_inoculated_bonuses();
+        }
+    }
+
+    update(timestamp) {
+        super.update(timestamp);
+        this.update_particle_spawning(timestamp);
+    }
+
+    update_particle_spawning(timestamp) {
+        this.particle_spawn_timer -= 16;
+        
+        if (this.particle_spawn_timer <= 0) {
+            this.particle_spawn_timer = this.particle_spawn_interval;
+            this.spawn_inoculated_particle();
+        }
+    }
+
+    spawn_inoculated_particle() {
+        if (!window.game_state || !window.game_state.effects) {
+            return;
+        }
+
+        const target = this.get_target();
+        if (!target) {
+            return;
+        }
+
+        const particle = this.create_inoculated_particle(target);
+        if (particle) {
+            window.game_state.effects.push(particle);
+        }
+    }
+
+    get_target() {
+        if (!window.game_state || !window.game_state.enemies) {
+            return null;
+        }
+
+        return window.game_state.enemies.find(enemy => 
+            enemy.status_effects && 
+            enemy.status_effects.includes(this)
+        );
+    }
+
+    create_inoculated_particle(target) {
+        const angle = Math.random() * Math.PI * 2;
+        const distance = Math.random() * target.radius * 0.8;
+        const particle_x = target.x + Math.cos(angle) * distance;
+        const particle_y = target.y + Math.sin(angle) * distance;
+
+        return new InoculatedParticle(particle_x, particle_y);
+    }
+
+    get_size_multiplier() {
+        return this.size_multiplier;
+    }
+
+    get_speed_multiplier() {
+        return this.speed_multiplier;
+    }
+}
+
+class InoculatedParticle {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.radius = Math.random() * 1.5 + 0.5;
+        this.life = 30;
+        this.max_life = 30;
+        this.opacity = 1.0;
+        this.velocity_x = (Math.random() - 0.5) * 0.5;
+        this.velocity_y = (Math.random() - 0.5) * 0.5;
+        this.color = '#FFA500';
+    }
+
+    update() {
+        this.x += this.velocity_x;
+        this.y += this.velocity_y;
+        this.life--;
+        this.opacity = this.life / this.max_life;
+    }
+
+    draw(ctx) {
+        if (this.life <= 0) {
+            return;
+        }
+
+        ctx.save();
+        ctx.globalAlpha = this.opacity;
+        ctx.fillStyle = this.color;
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+
+    is_alive() {
+        return this.life > 0;
+    }
+}
+
+window.InoculatedEffect = InoculatedEffect;
+window.InoculatedParticle = InoculatedParticle;

--- a/scripts/entities/status_effects/interfered_effect.js
+++ b/scripts/entities/status_effects/interfered_effect.js
@@ -1,6 +1,6 @@
 class InterferedEffect extends BaseStatusEffect {
-    constructor(duration_ms) {
-        super(duration_ms);
+    constructor(duration_ms, source_category = STATUS_EFFECT_SOURCES.IMMUNE_CELL) {
+        super(duration_ms, source_category);
         this.speed_reduction_factor = 0.5;
     }
 

--- a/scripts/entities/towers/interferon.js
+++ b/scripts/entities/towers/interferon.js
@@ -50,7 +50,7 @@ class Interferon extends BaseTower {
 
         window.game_state.enemies.forEach(enemy => {
             if (this.is_in_range(enemy)) {
-                const interfered_effect = new InterferedEffect(effect_duration);
+                const interfered_effect = new InterferedEffect(effect_duration, STATUS_EFFECT_SOURCES.IMMUNE_CELL);
                 enemy.add_status_effect(interfered_effect);
             }
         });

--- a/scripts/factories/enemy_factory.js
+++ b/scripts/factories/enemy_factory.js
@@ -8,6 +8,7 @@ class EnemyFactory {
         this.register_enemy_type(ENEMY_TYPES.BASIC, BasicEnemy);
         this.register_enemy_type(ENEMY_CATEGORIES.MICROBE, Microbe);
         this.register_enemy_type(PATHOGEN_TYPES.MYCETOMA, Mycetoma);
+        this.register_enemy_type(PATHOGEN_TYPES.RICKETTSIA, Rickettsia);
     }
 
     register_enemy_type(type_name, enemy_class) {

--- a/scripts/systems/adaptation_system.js
+++ b/scripts/systems/adaptation_system.js
@@ -180,9 +180,18 @@ class AdaptationSystem {
         return adaptation ? adaptation.get_free_placement_chance() : 0;
     }
 
-    get_status_effect_duration_multiplier() {
+    get_status_effect_duration_multiplier(source_category = STATUS_EFFECT_SOURCES.OTHER) {
         const adaptation = this.get_adaptation(ADAPTATION_TYPES.CHRONIC_INFLAMMATION);
-        return adaptation ? adaptation.get_status_effect_duration_multiplier() : 1.0;
+        
+        if (!adaptation) {
+            return 1.0;
+        }
+
+        if (source_category === STATUS_EFFECT_SOURCES.IMMUNE_CELL) {
+            return adaptation.get_status_effect_duration_multiplier();
+        }
+
+        return 1.0;
     }
 
     get_energy_per_kill() {

--- a/scripts/systems/audio_system.js
+++ b/scripts/systems/audio_system.js
@@ -12,7 +12,8 @@ const AUDIO_CONFIG = {
         PLACE_TOWER: 'sfx_place_tower',
         PROJECT_WAVE: 'sfx_project_wave',
         SHOOT_PROJECTILE: 'sfx_shoot_projectile',
-        SPAWN_ENEMY: 'sfx_spawn_enemy'
+        SPAWN_ENEMY: 'sfx_spawn_enemy',
+        APPLY_LIGHTNING: 'sfx_apply_lightning'
     },
     DEFAULT_VOLUME: 0.7,
     MAX_CONCURRENT_INSTANCES: 5

--- a/scripts/systems/status_effect_system.js
+++ b/scripts/systems/status_effect_system.js
@@ -11,9 +11,14 @@ class StatusEffectSystem {
         });
     }
 
-    apply_interfered(target, duration_ms) {
-        const interfered_effect = new InterferedEffect(duration_ms);
-        target.add_status_effect(interfered_effect);
+    apply_interfered(target, duration_ms, source_category = STATUS_EFFECT_SOURCES.IMMUNE_CELL) {
+        const interfered_effect = new InterferedEffect(duration_ms, source_category);
+        return target.add_status_effect(interfered_effect);
+    }
+
+    apply_inoculated(target) {
+        const inoculated_effect = new InoculatedEffect();
+        return target.add_status_effect(inoculated_effect);
     }
 
     remove_all_status_effects(target) {
@@ -25,12 +30,38 @@ class StatusEffectSystem {
         }
     }
 
+    remove_immune_cell_status_effects(target) {
+        if (!target.status_effects) {
+            return;
+        }
+
+        const effects_to_remove = target.status_effects.filter(effect => 
+            effect.is_from_immune_cell()
+        );
+
+        effects_to_remove.forEach(effect => {
+            effect.remove_effect(target);
+            const effect_index = target.status_effects.indexOf(effect);
+            if (effect_index !== -1) {
+                target.status_effects.splice(effect_index, 1);
+            }
+        });
+    }
+
     get_status_effects_of_type(target, effect_type) {
         if (!target.status_effects) {
             return [];
         }
         
         return target.status_effects.filter(effect => effect.get_type() === effect_type);
+    }
+
+    get_status_effects_from_source(target, source_category) {
+        if (!target.status_effects) {
+            return [];
+        }
+        
+        return target.status_effects.filter(effect => effect.get_source_category() === source_category);
     }
 }
 


### PR DESCRIPTION
# 📜 Summary
* Closes #46.

# 💡 Context
Implemented **Rickettsia** pathogen (Set 2 of Pathogens) with full gameplay functionality:
- **Rickettsia** - Orange bacteria pathogen with 40 HP, 0.5 speed, 20 radius that moves toward Cell Core
- **Inoculation Behavior** - Every 2 seconds, targets random eligible Microbes within 200px range
- **Inoculated Status Effect** - Grants 50% size and speed increase, clears immune cell effects, provides immunity to immune cell status effects
- **Visual Effects** - Lightning bolt connection with zigzag pattern and cyan glow (0.5 seconds)
- **Audio Integration** - Added `sfx_apply_lightning.ogg` sound effect support
- **Pathogen Pool** - Added Rickettsia to spawn rotation alongside existing Mycetoma

# 📝 Other Info
- **Status Effect Source Tracking** - Implemented categorization system (`IMMUNE_CELL`, `PATHOGEN`, ...) to identify effect origins
- **Chronic Inflammation Update** - Modified adaptation to only boost duration of immune cell-applied status effects, not pathogen effects
- **Visual Feedback Systems** - Added "IMMUNE" text display for blocked effects and faint particle emission for inoculated microbes
- **Race Condition Fixes** - Added comprehensive null guards throughout Rickettsia and status effect systems to prevent crashes during concurrent array modifications